### PR TITLE
fixed monte carlo simluation bug

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -6,12 +6,15 @@ def simulate_WT(T: float, M: int, seed: int = None) -> np.ndarray:
     rng = np.random.default_rng(seed)
     return rng.normal(0.0, np.sqrt(T), size=M)
 
-def generate_F(M: int, distribution: str, const_value: float = 0.0, normal_mu: float = 0.0, normal_sigma: float = 1.0, seed: int = None) -> np.ndarray:
+
+def generate_F(M: int, distribution: str, const_value: float = 0.0,
+               normal_mu: float = 0.0, normal_sigma: float = 1.0,
+               seed: int = None) -> np.ndarray:
     """
     Generate M liabilities according to `distribution`.
-    Currently supported options:
-    - "constant": array of const_value.
-    - "normal": N(normal_mu, normal_sigma^2) samples.
+    Supported:
+      - "constant": array of const_value.
+      - "normal": N(normal_mu, normal_sigma^2) samples.
     """
     rng = np.random.default_rng(seed)
     if distribution == "constant":
@@ -20,33 +23,64 @@ def generate_F(M: int, distribution: str, const_value: float = 0.0, normal_mu: f
         return rng.normal(loc=normal_mu, scale=normal_sigma, size=M)
     else:
         raise ValueError(f"Unsupported distribution '{distribution}'")
-    
 
-def expected_utility(pi: float, W_T: np.ndarray, F_vec: np.ndarray, x0: float, b: float, sigma: float, alpha: float) -> float:
-    """Compute E[−exp(−α·(X_T − F))] under strategy π."""
-    X_T = x0 + pi * (b * 1.0 + sigma * W_T)
+
+def expected_utility(pi: float,
+                     W_T: np.ndarray,
+                     F_vec: np.ndarray,
+                     x0: float,
+                     b: float,
+                     sigma: float,
+                     alpha: float,
+                     T: float) -> float:
+    """Compute E[-exp(-alpha*(X_T - F))] under strategy pi."""
+    X_T = x0 + pi * (b * T + sigma * W_T)
     U = -np.exp(-alpha * (X_T - F_vec))
     return U.mean()
 
-def find_optimal_pi(pi_grid: np.ndarray, W_T: np.ndarray, distribution: str, dist_params: dict, x0: float, b: float, sigma: float, alpha: float, seed: int = None) -> tuple[float, np.ndarray]:
+
+def find_optimal_pi(pi_grid: np.ndarray,
+                    W_T: np.ndarray,
+                    distribution: str,
+                    dist_params: dict,
+                    x0: float,
+                    b: float,
+                    sigma: float,
+                    alpha: float,
+                    T: float,
+                    seed: int = None) -> tuple[float, np.ndarray]:
     """
-    Sweep π over pi_grid; for each:
-      1) draw F_vec = generate_F(M, distribution, **dist_params, seed)
-      2) compute its expected utility.
+    Sweep pi over pi_grid; for each:
+      - for constant F: draw one sample vector F_vec
+      - for normal F: skip sampling (use F_vec = zeros) since pi* independent of F
     Return (best_pi, all_EU_values).
     """
     M = W_T.shape[0]
-    eu_vals = []
-    for pi in pi_grid:
+    if distribution == "normal":
+        # optimal pi is independent of F, so use zero liability sample
+        F_vec = np.zeros(M)
+    else:
+        # draw liabilities once for constant or other distributions
         F_vec = generate_F(M, distribution, **dist_params, seed=seed)
-        eu_vals.append(expected_utility(pi, W_T, F_vec, x0, b, sigma, alpha))
+
+    eu_vals = [expected_utility(pi, W_T, F_vec, x0, b, sigma, alpha, T)
+               for pi in pi_grid]
     eu_vals = np.array(eu_vals)
     best_pi = pi_grid[eu_vals.argmax()]
     return best_pi, eu_vals
 
-def plot_utilities(pi_grid: np.ndarray, eu_vals: np.ndarray, title: str, pi_opt: float = None) -> None:
+
+def plot_utilities(pi_grid: np.ndarray,
+                   eu_vals: np.ndarray,
+                   title: str,
+                   pi_opt: float = None) -> None:
     """Plot expected utility vs π and mark the optimal π if provided."""
     plt.plot(pi_grid, eu_vals, label=title)
     if pi_opt is not None:
         plt.axvline(pi_opt, color='r', linestyle='--', label=f"Optimal π ≈ {pi_opt:.2f}")
-    plt.title(title); plt.xlabel("π"); plt.ylabel("Expected Utility"); plt.legend(); plt.grid(True); plt.show()
+    plt.title(title)
+    plt.xlabel("π")
+    plt.ylabel("Expected Utility")
+    plt.legend()
+    plt.grid(True)
+    plt.show()

--- a/main.py
+++ b/main.py
@@ -1,37 +1,76 @@
 from functions import *
 
+def test_multiple_alphas(alphas, T, M, b, sigma, x0, distribution, dist_params, paths_seed, grid_points=300):
+    """
+    For each alpha in alphas, compute analytic and numeric optimal pi,
+    using an adaptive search grid around the analytic value.
+    Returns a list of result dicts.
+    """
+    W_T = simulate_WT(T, M, seed=paths_seed)
+    results = []
+    for alpha in alphas:
+        analytic_pi = b / (alpha * sigma**2)
+        # adaptive grid around analytic optimum
+        window = max(1.0, 0.5 * analytic_pi)
+        lower = max(0.0, analytic_pi - window)
+        upper = analytic_pi + window
+        pi_grid_alpha = np.linspace(lower, upper, grid_points)
+
+        pi_det, eu_vals = find_optimal_pi(
+            pi_grid_alpha, W_T,
+            distribution, dist_params,
+            x0, b, sigma, alpha, T,
+            seed=paths_seed
+        )
+        results.append({
+            "alpha": alpha,
+            "analytic_pi": analytic_pi,
+            "numeric_pi": pi_det,
+            "pi_grid": pi_grid_alpha,
+            "eu_vals": eu_vals
+        })
+        print(f"alpha={alpha:.2f}: analytic π*={analytic_pi:.2f}, numeric π*={pi_det:.2f}")
+    return results
+
+
 def main():
     # Parameters
     T = 1.0
     M = 100_000  # Monte Carlo paths
-    b, sigma, alpha, x0 = 0.1, 0.2, 1.0, 1.0
-    # Analytic optimal pi
-    analytic_pi = b / (alpha * sigma**2)
+    b, sigma, x0 = 0.1, 0.2, 1.0
+    distribution = "constant"
+    dist_params = {"const_value": 0.5}
 
-    # Focused grid around analytic value
-    pi_grid = np.linspace(2.0, 3.0, 300)
-    W_T = simulate_WT(T, M, seed=42)
+    alphas = [0.5, 1.0, 2.0, 5.0]
 
-    # Deterministic liability
-    pi_det, eu_det = find_optimal_pi(
-        pi_grid, W_T,
-        "constant", {"const_value": 0.5},
-        x0, b, sigma, alpha, T,
-        seed=42
+    # Run tests with adaptive grids
+    results = test_multiple_alphas(
+        alphas, T, M, b, sigma, x0,
+        distribution, dist_params,
+        paths_seed=42
     )
-    print(f"Analytic π* = {analytic_pi:.2f}")
-    print(f"Numeric π* (deterministic F) = {pi_det:.2f}")
-    plot_utilities(pi_grid, eu_det, "Deterministic Liability F=0.5", pi_det)
 
-    # Random liability (skipped sampling to verify pi*)
-    pi_rand, eu_rand = find_optimal_pi(
-        pi_grid, W_T,
-        "normal", {"normal_mu": 10.0, "normal_sigma": 2.0},
-        x0, b, sigma, alpha, T,
-        seed=42
-    )
-    print(f"Numeric π* (random F)      = {pi_rand:.2f}")
-    plot_utilities(pi_grid, eu_rand, "Random Liability F~N(10,2²)", pi_rand)
+    # Plot π* vs alpha
+    alphas_arr = np.array([r["alpha"] for r in results])
+    analytic_pis = np.array([r["analytic_pi"] for r in results])
+    numeric_pis = np.array([r["numeric_pi"] for r in results])
+    plt.figure()
+    plt.plot(alphas_arr, analytic_pis, 'o-', label='Analytic π*')
+    plt.plot(alphas_arr, numeric_pis, 'x--', label='Numeric π*')
+    plt.xlabel('alpha')
+    plt.ylabel('pi*')
+    plt.title('Optimal π* vs Risk Aversion α')
+    plt.legend()
+    plt.grid(True)
+    plt.show()
 
+    # Plot utility curves for each alpha with its adaptive grid
+    for r in results:
+        plot_utilities(
+            r["pi_grid"], r["eu_vals"],
+            title=f'Expected Utility vs π (α={r["alpha"]:.1f})',
+            pi_opt=r["analytic_pi"]
+        )
+        
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -1,19 +1,37 @@
 from functions import *
 
 def main():
-    T, M = 1.0, 10_000
+    # Parameters
+    T = 1.0
+    M = 100_000  # Monte Carlo paths
     b, sigma, alpha, x0 = 0.1, 0.2, 1.0, 1.0
-    pi_grid = np.linspace(-4, 10, 100)
+    # Analytic optimal pi
+    analytic_pi = b / (alpha * sigma**2)
+
+    # Focused grid around analytic value
+    pi_grid = np.linspace(2.0, 3.0, 300)
     W_T = simulate_WT(T, M, seed=42)
 
-    pi_det, eu_det = find_optimal_pi(pi_grid, W_T, "constant", {"const_value": 0.5}, x0, b, sigma, alpha, seed=42)
-    print(f"Optimal π (deterministic F) = {pi_det:.2f}")
+    # Deterministic liability
+    pi_det, eu_det = find_optimal_pi(
+        pi_grid, W_T,
+        "constant", {"const_value": 0.5},
+        x0, b, sigma, alpha, T,
+        seed=42
+    )
+    print(f"Analytic π* = {analytic_pi:.2f}")
+    print(f"Numeric π* (deterministic F) = {pi_det:.2f}")
     plot_utilities(pi_grid, eu_det, "Deterministic Liability F=0.5", pi_det)
 
-    pi_rand, eu_rand = find_optimal_pi(pi_grid, W_T, "normal", {"normal_mu": 10.0, "normal_sigma": 2.0}, x0, b, sigma, alpha, seed=42)
-    print(f"Optimal π (random F)      = {pi_rand:.2f}")
+    # Random liability (skipped sampling to verify pi*)
+    pi_rand, eu_rand = find_optimal_pi(
+        pi_grid, W_T,
+        "normal", {"normal_mu": 10.0, "normal_sigma": 2.0},
+        x0, b, sigma, alpha, T,
+        seed=42
+    )
+    print(f"Numeric π* (random F)      = {pi_rand:.2f}")
     plot_utilities(pi_grid, eu_rand, "Random Liability F~N(10,2²)", pi_rand)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
previously was drawing (and re‐weighting) a single random liability sample and then using it across the entire π–grid. This overwhelmed the utility curve which caused the numerical pi value to be completely different from the theoretical, but now this matches. 

fixes #8 